### PR TITLE
add stm32g0316-disco dev board

### DIFF
--- a/boards.stm32.mk
+++ b/boards.stm32.mk
@@ -147,3 +147,4 @@ $(eval $(call stm32l4board,nucleo-l4r5zi,GPIOC,GPIO7,GPIOB,GPIO7))
 
 # STM32G0 boards
 $(eval $(call stm32g0board,nucleo-g071rb,GPIOA,GPIO5))
+$(eval $(call stm32g0board,stm32g0316-disco,GPIOA,GPIO12))


### PR DESCRIPTION
GPIOA,GPIO12 are based on the docs, that says:
"LD2 USER - This green LED is connected to the GPIO PA12 of the STM32G031J6
microcontroller."

