### PR TITLE
Added support for the devebox-stm32f407vgt6 target.

### DIFF
--- a/boards.stm32.mk
+++ b/boards.stm32.mk
@@ -129,6 +129,7 @@ $(eval $(call stm32f4board,nucleo-f446re,GPIOA,GPIO5))
 $(eval $(call stm32f4board,olimex-p405,GPIOC,GPIO12))
 $(eval $(call stm32f4board,olimex-e407,GPIOC,GPIO13))
 $(eval $(call stm32f4board,black-stm32f407ve-v2.0,GPIOA,GPIO6))
+$(eval $(call stm32f4board,devebox-stm32f407vgt6,GPIOA,GPIO1))
 
 # STM32F7 boards
 $(eval $(call stm32f7board,stm32f746g-disco,GPIOI,GPIO1))


### PR DESCRIPTION
General information about the board can be found on github, under:
https://github.com/mcauser/MCUDEV_DEVEBOX_F407VGT6

The full schematic is documented here:
https://github.com/mcauser/MCUDEV_DEVEBOX_F407VGT6/blob/master/docs/STM32F407VX_M_schematics.pdf

Finally a picture of the product can be found here:
https://github.com/mcauser/MCUDEV_DEVEBOX_F407VGT6/blob/master/docs/STM32F407VGT6.jpg